### PR TITLE
MMDAgent-EXへの対応

### DIFF
--- a/MMDAgent-EX.md
+++ b/MMDAgent-EX.md
@@ -1,0 +1,39 @@
+# MMDAgent-EX への更新手順
+
+## 前提
+
+
+すでに MMDAgent_Example-1.4 をダウンロード済みであり、MMDAgent を利用して NH-chat が実行できる状態になっている
+
+## MMDAgent-EX のダウンロード
+
+1. [公式サイト](https://mmdagent-ex.dev/download/) からWindows版のMMDAgent-EXが入ったzipファイルをダウンロード （ver2.0のzipファイルへの直リンクは[こちら](https://mmdagent.lee-lab.org/dl/app/MMDAgent-EX-2.0-20210116-win32.zip)）
+
+1. ダウンロードしたzipファイルを `NH-chat/tools ` 以下に展開する
+
+1. `NH-chat/tools/MMDAgent_Example.fst` と `NH-chat/tools/MMDAgent_Example.mdf` を MMDAgent_Example-1.4 に配置する（既存のファイルを置き換える）
+
+## NH-chat 用の設定・変更点
+1. MMDAgent-EXでは、文字コードが Shift-JIS から UTF-8 に変更されているため、ログを受け取る部分など、インターフェース部分で扱う文字コードも変更
+
+1. `src/refData/path.csv` に MMDAgent-EXのパスを追加し、 `nh_path.path["MMDAgent"]` を呼び出しているところを `nh_path.path["MMDAgent-EX"]` に変更
+
+    ```
+    MMDAgent-EX,../../tools/MMDAgent-EX-2.0-20210116-win32,MMDAgent-EX.exeがあるフォルダ
+    ```
+
+1. `src/Interface/tools.py` でMMDAgent実行中の時にタスクをKillする部分の、対象タスクを `MMDAgent` から `MMDAgent-EX` に変更
+
+1. MMDAgent_Example.mdf 内に設定を追加し、MMDAgent 1.4バージョンと挙動を合わせる
+
+    ```
+    # Socketプラグインを有効化（MMDAgent-EXには機能が内蔵されている）
+    Plugin_Remote_EnableServer=true
+    Plugin_Remote_Port=39390 # defaultは39392
+
+    # 字幕の削除（デフォルトは字幕が表示される）
+    show_caption=false
+
+    # 内蔵されているJuliusを無効化
+    exclude_Plugin_Julius=yes
+    ```

--- a/src/Interface/nh_path.py
+++ b/src/Interface/nh_path.py
@@ -14,7 +14,7 @@ class NHPath:
         fp = fp.replace(os.sep, "/")
         self.print_debug("read:{}".format(fp))
         self.path = {}
-        with open(fp, encoding="shift-jis") as f:
+        with open(fp, encoding="utf-8") as f:
             reader = csv.reader(f)
             for row in reader:
                 path_tmp = row[1]

--- a/src/Interface/tools.py
+++ b/src/Interface/tools.py
@@ -230,20 +230,20 @@ class MMDAgent(AbstractCommunicator):
         
         # すでにMMDAgentが実行中の場合はキル
         self.m_task = ManageTask()
-        if self.m_task.confirm_task("MMDAgent") == True:
-            self.m_task.kill_task("MMDAgent")
+        if self.m_task.confirm_task("MMDAgent-EX") == True:
+            self.m_task.kill_task("MMDAgent-EX")
             time.sleep(1)
         super(MMDAgent, self).__init__(host, port)
         
         # read path	
         nh_path = NHPath()
         try:
-            mmd_exe_path = nh_path.path["MMDAgent"]
+            mmd_exe_path = nh_path.path["MMDAgent-EX"]
             self.mmd_example_path = nh_path.path["MMDExample"]
         except KeyError:
             print("MMDAgent or MMDExample path undefined")
             sys.exit()
-        cmd = "{}/MMDAgent.exe {}/MMDAgent_Example.mdf"\
+        cmd = "{}/MMDAgent-EX.exe {}/MMDAgent_Example.mdf"\
             .format(mmd_exe_path, self.mmd_example_path)
         
         # run MMDAgent
@@ -302,7 +302,7 @@ class MMDAgent(AbstractCommunicator):
             self.is_speaking = True
             speak_start = time.time()
             limit = 5 + len(speech) / 2.5
-            self.send_line(command, "shift_jis")
+            self.send_line(command, "utf-8")
             while self.is_speaking:
                 elapsed = time.time() - speak_start
                 if elapsed > limit:

--- a/src/refData/path.csv
+++ b/src/refData/path.csv
@@ -1,5 +1,7 @@
-MMDAgent,../../tools/MMDAgent_win32-1.4,MMDAgent.exe‚ª‚ ‚éƒtƒHƒ‹ƒ_
-MMDExample,../../tools/MMDAgent_Example-1.4,MMDAgent_Example.mdf‚ª‚ ‚éƒtƒHƒ‹ƒ_
-OpenFace,../../tools/OpenFace_2.2.0_win_x64,FaceLandmarkImg.exe‚ª‚ ‚éƒtƒHƒ‹ƒ_
-openSMILE,../../tools/opensmile-3.0-win-x64,"bin,configƒtƒHƒ‹ƒ_‚Ì‚ ‚éƒtƒHƒ‹ƒ_"
-julius,../../tools/dictation-kit-4.5,"bin,configƒtƒHƒ‹ƒ_‚Ì‚ ‚éƒtƒHƒ‹ƒ_"
+MMDAgent,../../tools/MMDAgent_win32-1.4,MMDAgent.exeãŒã‚ã‚‹ãƒ•ã‚©ãƒ«ãƒ€
+MMDAgent-EX,../../tools/MMDAgent-EX-2.0-20210116-win32,MMDAgent-EX.exeãŒã‚ã‚‹ãƒ•ã‚©ãƒ«ãƒ€
+MMDExample,../../tools/MMDAgent_Example-1.4,MMDAgent_Example.mdfãŒã‚ã‚‹ãƒ•ã‚©ãƒ«ãƒ€
+MMDExample-EX,../../tools/MMDAgent-EX_Example,MMDAgent-EX_Example.mdfãŒã‚ã‚‹ãƒ•ã‚©ãƒ«ãƒ€
+OpenFace,../../tools/OpenFace_2.2.0_win_x64,FaceLandmarkImg.exeãŒã‚ã‚‹ãƒ•ã‚©ãƒ«ãƒ€
+openSMILE,../../tools/opensmile-3.0-win-x64,"bin,configãƒ•ã‚©ãƒ«ãƒ€ã®ã‚ã‚‹ãƒ•ã‚©ãƒ«ãƒ€"
+julius,../../tools/dictation-kit-4.5,"bin,configãƒ•ã‚©ãƒ«ãƒ€ã®ã‚ã‚‹ãƒ•ã‚©ãƒ«ãƒ€"

--- a/tools/MMDAgent_Example.mdf
+++ b/tools/MMDAgent_Example.mdf
@@ -1,0 +1,137 @@
+# ----------------------------------------------------------------- #
+#           MMDAgent "Sample Script"                                #
+#           released by MMDAgent Project Team                       #
+#           http://www.mmdagent.jp/                                 #
+# ----------------------------------------------------------------- #
+#                                                                   #
+#  Copyright (c) 2009-2013  Nagoya Institute of Technology          #
+#                           Department of Computer Science          #
+#                                                                   #
+# Some rights reserved.                                             #
+#                                                                   #
+# This work is licensed under the Creative Commons Attribution 3.0  #
+# license.                                                          #
+#                                                                   #
+# You are free:                                                     #
+#  * to Share - to copy, distribute and transmit the work           #
+#  * to Remix - to adapt the work                                   #
+# Under the following conditions:                                   #
+#  * Attribution - You must attribute the work in the manner        #
+#    specified by the author or licensor (but not in any way that   #
+#    suggests that they endorse you or your use of the work).       #
+# With the understanding that:                                      #
+#  * Waiver - Any of the above conditions can be waived if you get  #
+#    permission from the copyright holder.                          #
+#  * Public Domain - Where the work or any of its elements is in    #
+#    the public domain under applicable law, that status is in no   #
+#    way affected by the license.                                   #
+#  * Other Rights - In no way are any of the following rights       #
+#    affected by the license:                                       #
+#     - Your fair dealing or fair use rights, or other applicable   #
+#       copyright exceptions and limitations;                       #
+#     - The author's moral rights;                                  #
+#     - Rights other persons may have either in the work itself or  #
+#       in how the work is used, such as publicity or privacy       #
+#       rights.                                                     #
+#  * Notice - For any reuse or distribution, you must make clear to #
+#    others the license terms of this work. The best way to do this #
+#    is with a link to this web page.                               #
+#                                                                   #
+# See http://creativecommons.org/ for details.                      #
+# ----------------------------------------------------------------- #
+
+# Cartoon rendering
+
+use_cartoon_rendering=true
+use_mmd_like_cartoon=true
+cartoon_edge_width=0.35
+cartoon_edge_step=1.2
+cartoon_edge_selected_color=1.0,0.0,0.0,1.0
+
+# Camera
+
+camera_rotation=0.0,0.0,0.0
+camera_transition=0.0,13.0,0.0
+camera_distance=100.0
+camera_fovy=16.0
+
+# Stage
+
+stage_size=25.0,25.0,40.0
+
+# Fps
+
+show_fps=false
+fps_position=-2.5,22.0,3.0
+
+# Window
+
+window_size=600,600
+full_screen=false
+
+# Log
+
+log_size=80,30
+log_position=-17.5,3.0,-20.0
+log_scale=1.0
+
+# Light
+
+light_direction=0.5,1.0,0.5,0.0
+light_intensity=0.6
+light_color=1.0,1.0,1.0
+
+# Campus
+
+campus_color=0.0,0.0,0.2
+
+# OpenGL
+
+max_multi_sampling=4
+
+# Motion
+
+motion_adjust_time=0.0
+lypsync_priority=100.0
+
+# Bullet Physics
+
+bullet_fps=120
+gravity_factor=2.0
+
+# User interface
+
+rotate_step=4.5
+translate_step=0.5
+distance_step=4.0
+fovy_step=1.0
+
+# Shadow mapping
+
+use_shadow_mapping=false
+shadow_mapping_texture_size=1024
+shadow_mapping_self_density=1.0
+shadow_mapping_floor_density=0.5
+shadow_mapping_light_first=true
+
+# Comment
+
+display_comment_time=0.0
+
+# Model
+
+max_num_model=3
+
+
+#############################
+#   ADDED for MMDAgent EX   #
+#############################
+# configuration in .mdf to enable server function
+Plugin_Remote_EnableServer=true
+Plugin_Remote_Port=39390 # defaultは39392
+
+# hide caption
+show_caption=false
+
+# disable embedding Julius function
+exclude_Plugin_Julius=yes


### PR DESCRIPTION
# 内容

NH-chatで利用しているMMDAgentを、新バージョンの[MMDAgent-EX](https://mmdagent-ex.dev/)に置き換えて動かせるようにする。

# 詳細

- `MMDAgent-EX.md` には、導入の手順を記載しました。
- `src/refData/path.csv` の文字コードをShift_JISからUTF-8に変更しました。
- `src/Interface/tools.py` で使われているプログラムをMMDAgentからMMDAgent-EXに変更しました。
- `tools/MMDAgent_Example.mdf` には、元のMMDAgentベースのシステムと合わせるための設定を追加したものをサンプルとして配置しました。